### PR TITLE
CLOUDSTACK-9342: Site to Site VPN PFS not being set correctly

### DIFF
--- a/systemvm/patches/debian/config/opt/cloud/bin/configure.py
+++ b/systemvm/patches/debian/config/opt/cloud/bin/configure.py
@@ -528,7 +528,10 @@ class CsSite2SiteVpn(CsDataBag):
         file.addeq(" ikelifetime=%s" % self.convert_sec_to_h(obj['ike_lifetime']))
         file.addeq(" esp=%s" % obj['esp_policy'])
         file.addeq(" salifetime=%s" % self.convert_sec_to_h(obj['esp_lifetime']))
-        file.addeq(" pfs=%s" % CsHelper.bool_to_yn(obj['dpd']))
+        if "modp" in obj['esp_policy']:
+            file.addeq(" pfs=yes")
+        else:
+            file.addeq(" pfs=no")
         file.addeq(" keyingtries=2")
         file.addeq(" auto=start")
         file.addeq(" forceencaps=%s" % CsHelper.bool_to_yn(obj['encap']))


### PR DESCRIPTION
Bug in code set PFS to the same value (yes/no) as DPD.

file.addeq(" pfs=%s" % CsHelper.bool_to_yn(obj['dpd']))
